### PR TITLE
fix: change README.md astro link

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,6 @@ All commands are run from the root of the project, from a terminal:
 | `npm run astro ...`    | Run CLI commands like `astro add`, `astro preview` |
 | `npm run astro --help` | Get help using the Astro CLI                       |
 
-## 👀 Want to learn more?
+## 👀 Want to learn more about astro?
 
-Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+Feel free to check [the astro documentation](https://docs.astro.build).


### PR DESCRIPTION
removing link to "our discord" and "our documentation" is misleading.